### PR TITLE
Minor improvements - Part 2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
           "-o ble -o alloc",
           "-o embassy",
           "-o probe-rs",
-          "-o stack_protector"
+          "-o stack-protector"
         ]
         # Exclude some combinations that are not supported
         exclude:
@@ -74,7 +74,7 @@ jobs:
           components: clippy,rustfmt,rust-src
 
       # Rust toolchain for RISC-V:
-      - if: matrix.chip != 'esp32' && matrix.chip != 'esp32s2' && matrix.chip != 'esp32s3' && matrix.options == '-o stack_protector'
+      - if: matrix.chip != 'esp32' && matrix.chip != 'esp32s2' && matrix.chip != 'esp32s3' && matrix.options == '-o stack-protector'
         uses: dtolnay/rust-toolchain@nightly
         with:
           target: riscv32imc-unknown-none-elf,riscv32imac-unknown-none-elf

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,13 +43,18 @@ jobs:
         options: [
           "",
           "-o alloc",
-          "-o wifi",
-          "-o ble",
+          "-o wifi -o alloc",
+          "-o ble -o alloc",
           "-o embassy",
           "-o probe-rs",
           "-o stack_protector"
         ]
-
+        # Exclude some combinations that are not supported
+        exclude:
+          - chip: "esp32h2"
+            options: "-o wifi -o alloc"
+          - chip: "esp32s2"
+            options: "-o ble -o alloc"
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,88 @@
+name: CI
+on:
+  push:
+    paths-ignore:
+      - "**/README.md"
+  pull_request:
+    paths-ignore:
+      - "**/README.md"
+  workflow_dispatch:
+
+env:
+  CARGO_TERM_COLOR: always
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  SSID: ""
+  PASSWORD: ""
+
+# Cancel any currently running workflows from the same PR, branch, or
+# tag when a new workflow is triggered.
+#
+# https://stackoverflow.com/a/66336834
+concurrency:
+  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+
+jobs:
+  verify:
+    name: "${{ matrix.chip }} | ${{ matrix.options }}"
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        chip: [
+            "esp32",
+            "esp32c2",
+            "esp32c3",
+            "esp32c6",
+            "esp32h2",
+            "esp32s2",
+            "esp32s3",
+          ]
+        options: [
+          "",
+          "-o alloc",
+          "-o wifi",
+          "-o ble",
+          "-o embassy",
+          "-o probe-rs",
+          "-o stack_protector"
+        ]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      # Rust toolchain for Xtensa:
+      - if: matrix.chip == 'esp32' || matrix.chip == 'esp32s2' || matrix.chip == 'esp32s3'
+        uses: esp-rs/xtensa-toolchain@v1.5
+        with:
+          default: true
+          buildtargets: ${{ matrix.chip }}
+          ldproxy: false
+
+      # Rust toolchain for RISC-V:
+      - if: matrix.chip != 'esp32' && matrix.chip != 'esp32s2' && matrix.chip != 'esp32s3'
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          target: riscv32imc-unknown-none-elf,riscv32imac-unknown-none-elf
+          components: clippy,rustfmt,rust-src
+
+      # Rust toolchain for RISC-V:
+      - if: matrix.chip != 'esp32' && matrix.chip != 'esp32s2' && matrix.chip != 'esp32s3' && matrix.options == '-o stack_protector'
+        uses: dtolnay/rust-toolchain@nightly
+        with:
+          target: riscv32imc-unknown-none-elf,riscv32imac-unknown-none-elf
+          components: clippy,rustfmt,rust-src
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Generate project
+        run: cargo run --release -- --chip ${{ matrix.chip }}  --headless ${{ matrix.options }} test
+
+      - name: Build and check the project
+        working-directory: test
+        run: |
+            cargo fmt -- --check
+            cargo clippy --no-deps -- -Dwarnings
+            cargo build --release

--- a/src/main.rs
+++ b/src/main.rs
@@ -107,7 +107,7 @@ static OPTIONS: &[GeneratorOptionItem] = &[
         chips: &[],
     }),
     GeneratorOptionItem::Option(GeneratorOption {
-        name: "stack_protector",
+        name: "stack-protector",
         display_name: "Enable stack-smash protection (Nightly only)",
         enables: &[],
         disables: &[],

--- a/src/main.rs
+++ b/src/main.rs
@@ -224,7 +224,8 @@ fn main() {
         process::exit(-1);
     }
 
-    // TODO verify valid options are given on command line
+    // Validate options
+    process_options(&args);
 
     let mut selected = if !args.headless {
         let repository = tui::Repository::new(args.chip, OPTIONS, &args.option);
@@ -408,4 +409,21 @@ fn process_file(
     }
 
     Some(res)
+}
+
+fn process_options(args: &Args) {
+    for option in &args.option {
+        // Find the matching option in OPTIONS
+        if let Some(option_item) = OPTIONS.iter().find(|item| item.name() == *option) {
+            // Check if the chip is supported
+            if !option_item.chips().iter().any(|chip| chip == &args.chip) {
+                eprintln!(
+                    "Error: Option {:?} is not supported for chip {:?}",
+                    option, args.chip
+                );
+            }
+        } else {
+            eprintln!("Error: Option {:?} not found", option);
+        }
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -415,8 +415,10 @@ fn process_options(args: &Args) {
     for option in &args.option {
         // Find the matching option in OPTIONS
         if let Some(option_item) = OPTIONS.iter().find(|item| item.name() == *option) {
-            // Check if the chip is supported
-            if !option_item.chips().iter().any(|chip| chip == &args.chip) {
+            // Check if the chip is supported. If the chip list is empty, all chips are supported
+            if !option_item.chips().iter().any(|chip| chip == &args.chip)
+                && !option_item.chips().is_empty()
+            {
                 eprintln!(
                     "Error: Option {:?} is not supported for chip {:?}",
                     option, args.chip

--- a/template/rust-toolchain.toml
+++ b/template/rust-toolchain.toml
@@ -1,0 +1,15 @@
+[toolchain]
+#IF option("riscv")
+#IF !option("stack-protector")
+channel = "stable"
+#ENDIF
+#IF option("stack-protector")
+#+channel = "nightly"
+#ENDIF
+components = ["rust-src"]
+#REPLACE riscv32imac-unknown-none-elf rust_target
+targets = ["riscv32imac-unknown-none-elf"]
+#ENDIF
+#IF option("xtensa")
+#+channel = "esp"
+#ENDIF


### PR DESCRIPTION
- Adds some basic CI
  - We may need to come with a better strategy, but at least we are verifying some stuff already.
  - Example run: https://github.com/SergioGasquez/esp-generate/actions/runs/11158725726
- Adds a `rust-toolchain.toml` file
- Validates, in a very simple way, the arguments
- Unify the `stack-protector` name